### PR TITLE
Fix parsing format for domain.expire on UK domains

### DIFF
--- a/src/whois.uk.php
+++ b/src/whois.uk.php
@@ -36,7 +36,7 @@ class uk_handler {
             'owner.type' => 'Registrant type:',
             'domain.created' => 'Registered on:',
             'domain.changed' => 'Last updated:',
-            'domain.expires' => 'Renewal date:',
+            'domain.expires' => 'Expiry date:',
             'domain.nserver' => 'Name servers:',
             'domain.sponsor' => 'Registrar:',
             'domain.status' => 'Registration status:',


### PR DESCRIPTION
Expiry field-name has changed.
